### PR TITLE
add feeding for every user for user's activity

### DIFF
--- a/Cinemate.API/Controllers/ProfileController.cs
+++ b/Cinemate.API/Controllers/ProfileController.cs
@@ -1,7 +1,10 @@
-﻿using Cinemate.Core.Contracts.Profile;
+﻿using Azure;
+using Cinemate.Core.Contracts.Profile;
+using Cinemate.Core.Extensions;
 using Cinemate.Core.Service_Contract;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Cinemate.Repository.Abstractions;
 
 namespace Cinemate.API.Controllers
 {
@@ -85,5 +88,11 @@ namespace Cinemate.API.Controllers
             var watchedMovies = await _profileService.GetAllWatchlist(cancellationToken);
             return Ok(watchedMovies);
         }
-    }
+		[HttpGet("feed")]
+		public async Task<IActionResult> GetUserFeed(CancellationToken cancellationToken)
+		{
+			var result = await _profileService.GetFeedForUserAsync(User.GetUserId()!, cancellationToken);
+			return result.IsSuccess ? Ok(result.Value) : result.ToProblem();
+		}
+	}
 }

--- a/Cinemate.Core/Contracts/Profile/FeedResponse.cs
+++ b/Cinemate.Core/Contracts/Profile/FeedResponse.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Cinemate.Core.Contracts.Profile
+{
+	public record FeedResponse
+	(
+		string UserId,
+		string UserName,
+		string? ProfilePic,
+		string type,
+		string id,
+		string? PosterPath,
+		string? Name,
+		string? Description,
+		DateTime? CreatedOn
+	);
+}

--- a/Cinemate.Core/Errors/Authentication/AuthenticationError.cs
+++ b/Cinemate.Core/Errors/Authentication/AuthenticationError.cs
@@ -15,6 +15,7 @@ namespace Cinemate.Repository.Errors.Authentication
 			public static readonly Error DuplicatedConfirmation = new("User.DuplicatedInformation", "Email Already Confirmed", StatusCodes.Status400BadRequest);
 			public static readonly Error EmailNotConfirmed = new("User.EmailNotConfirmed", "Email is not confirmed", StatusCodes.Status401Unauthorized);
 			public static readonly Error UserEmailNotFound = new("User.UserEmailNotFound", "User Email NotFound", StatusCodes.Status404NotFound);
+			public static readonly Error UserNotFound = new("User.UserNotFound", "User with this Id NotFound", StatusCodes.Status404NotFound);
 			public static readonly Error DisabledUser = new("User.DisabledUser", "Disabled user, please contact your administrator", StatusCodes.Status401Unauthorized);
 			public static readonly Error InvalidRefreshToken = new("User.InvalidRefreshToken", "Invalid refresh token", StatusCodes.Status401Unauthorized);
 		}

--- a/Cinemate.Core/Extensions/UserExtensions.cs
+++ b/Cinemate.Core/Extensions/UserExtensions.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Cinemate.Core.Extensions
+{
+	public static class UserExtensions
+	{
+		public static string? GetUserId(this ClaimsPrincipal user)
+		{
+			return user.FindFirstValue(ClaimTypes.NameIdentifier);
+		}
+	}
+}

--- a/Cinemate.Core/Service Contract/IProfileService.cs
+++ b/Cinemate.Core/Service Contract/IProfileService.cs
@@ -19,15 +19,11 @@ namespace Cinemate.Core.Service_Contract
     {
         Task<UpdateProfileReauestBack> UpdateProfileAsync(UpdateProfileRequest request, CancellationToken cancellationToken = default);
         Task<OperationResult> DeleteAsync(CancellationToken cancellationToken = default);
-
         Task<IEnumerable<UserWatchedMovieResponseBack>> GetAllMoviesWatched(CancellationToken cancellationToken = default);
         Task<IEnumerable<UserLikeMovieResponseBack>> GetAllMoviesLiked(CancellationToken cancellationToken = default);
         Task< IEnumerable<UserRateMovieResponseBack>> GetAllMoviesRated(CancellationToken cancellationToken = default);
         Task<IEnumerable<UserReviewMovieResponseBack>> GetAllMoviesReviews(CancellationToken cancellationToken = default);
         Task<IEnumerable<UserWatchListMovieResponseBack>> GetAllWatchlist(CancellationToken cancellationToken = default);
-
-
-
-
-    }
+        Task<Result<IEnumerable<FeedResponse>>> GetFeedForUserAsync(string id, CancellationToken cancellationToken = default);
+	}
 }


### PR DESCRIPTION
implements the user feed functionality that displays activities from followed users, The feed aggregates likes, follows, reviews, and ratings from users that the current user follows.
1. Implemented Feed
• Added GetFeedForUserAsync method in ProfileService to aggregate activities.
• Queried activities across different entity types (likes, ratings, reviews, follows).
2. Added Error Handling
• Implemented proper validation and error handling for user not found scenarios.